### PR TITLE
Create ECR repository

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Don't search for .editorconfig in parent directories
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Markdown has special use for trailing whitespace
+[*.md]
+trim_trailing_whitespace = false
+
+# Python files
+[*.py]
+indent_style = space
+indent_size  = 4
+
+# Terraform/Terragrunt HCL files
+[*.tf,hcl}]
+indent_style = space
+indent_size  = 2

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,46 @@
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "2.2.1" # checkov:skip=CKV_TF_1
+
+  repository_name = var.prefix
+
+  repository_read_write_access_arns = [
+    module.github_actions_iam_role.iam_role_arn,
+  ]
+
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last 10 images",
+        selection = {
+          tagStatus   = "tagged",
+          countType   = "imageCountMoreThan",
+          countNumber = 10
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "eks_ecr_read_only" {
+  name        = "${var.prefix}-eks-ecr-read-only"
+  description = "Read-only access to ECR repository for EKS cluster"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+        Resource = module.ecr.repository_arn
+      }
+    ]
+  })
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -13,7 +13,7 @@ module "github_actions_iam_role" {
   role_policy_arns = [
     "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser",
   ]
 
   max_session_duration = 7200

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,6 +57,9 @@ module "eks" {
       max_size     = 3
       desired_size = 2
 
+      iam_role_additional_policies = {
+        ecr_read_only = aws_iam_policy.eks_ecr_read_only.arn,
+      }
     }
   }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,8 @@ output "github_actions_iam_role_arn" {
   description = "GitHub Actions IAM role ARN"
   value       = module.github_actions_iam_role.iam_role_arn
 }
+
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = module.ecr.repository_url
+}


### PR DESCRIPTION
* Create ECR repostory
* Add lifecycle policy to keep only last 10 images
* Allow read-only access from EKS cluster
* Allow pushing images from GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `.editorconfig` file for consistent coding style guidelines across various file types.
	- Added a new Terraform module for setting up an Amazon Elastic Container Registry (ECR) with read-only IAM access.
	- Enhanced the EKS module to include additional IAM policies for improved ECR interaction.
	- Added an output declaration for the ECR repository URL to facilitate integration with other services.

- **Bug Fixes**
	- Updated IAM role policy to enhance permissions for the Amazon EC2 Container Registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->