### PR TITLE
Build and push Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: app
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/hello-world:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/hello-world:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}


### PR DESCRIPTION
* Build Docker images for all merges/commits to `main` branch
* Tag the image with Git commit SHA hash, as well as the `latest` tag
* Push the image to the ECR repository we created before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for automated building and pushing of Docker images to Amazon ECR.
	- The workflow can be triggered on code pushes to the main branch or manually initiated.

- **Chores**
	- Added a configuration file for the GitHub Actions workflow to streamline CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->