### PR TITLE
Allow access to EKS from GitHub Actions

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,4 +66,21 @@ module "eks" {
   # Cluster access entry
   # To add the current caller identity as an administrator
   enable_cluster_creator_admin_permissions = true
+
+  access_entries = {
+    github_actions = {
+      principal_arn = module.github_actions_iam_role.iam_role_arn
+      policy_associations = {
+        deploy = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSEditPolicy"
+          access_scope = {
+            type = "namespace"
+            namespaces = [
+              var.k8s_namespace,
+            ]
+          }
+        }
+      },
+    }
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,9 @@ variable "prefix" {
   type        = string
   default     = "hello-world"
 }
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace to deploy to"
+  type        = string
+  default     = "hello-world"
+}


### PR DESCRIPTION
* Add EKS cluster access entry for GitHub Actions
* Allow deployments to specific namespace (parameterized via a variable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration block for managing access permissions for GitHub Actions in the EKS module.
	- Added a new variable for specifying the Kubernetes namespace for deployments, enhancing configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->