### PR TITLE
Expose web app via Ingress and ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Please refer to the Helm chart in the [chart](chart) directory for more details.
 
 Currently, the CI/CD is configured to deploy the application to the dedicated `hello-world` namespace in the Kubernetes cluster, creating it if it doesn't exist.
 
+The application is exposed via `Ingress` and a `LoadBalancer` service type and it can be accessed using something like this (example for macOS):
+
+```shell
+open http://$(kubectl get svc --namespace hello-world hello-world --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}") 
+```
+
 ## Author
 
 [Sergei Kolobov](mailto:skolobov@gmail.com)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,20 +40,19 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
+  type: LoadBalancer
   port: 80
 
 ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
   hosts:
-    - host: chart-example.local
+    - host: "*"
       paths:
-        - path: /
-          pathType: ImplementationSpecific
+        - /
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
* Change Kubernetes service type to `LoadBalancer`
* Enable `Ingress` in Kubernetes, allow any hostname
* Update instructions in top-level README


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the README.md with detailed instructions on the CI/CD deployment process and provided a command-line example for macOS users to access the application via LoadBalancer's IP address.
  
- **New Features**
	- Updated service configuration to expose the application externally via LoadBalancer.
	- Enabled ingress to allow routing of external HTTP(S) traffic, enhancing accessibility.
	- Improved ingress configurations for broader domain handling and simplified routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->