### PR TITLE
Add AWS Load Balancer Controller

### DIFF
--- a/terraform/load-balancer.tf
+++ b/terraform/load-balancer.tf
@@ -1,0 +1,55 @@
+module "load_balancer_controller_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.41.0" # checkov:skip=CKV_TF_1
+
+  role_name = "${var.prefix}-load-balancer-controller-role"
+
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    eks = {
+      provider_arn = module.eks.oidc_provider_arn
+
+      namespace_service_accounts = [
+        "kube-system:aws-load-balancer-controller",
+      ]
+    }
+  }
+}
+
+resource "helm_release" "load_balancer_controller" {
+  name       = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.8.2"
+
+  set {
+    name  = "clusterName"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "false"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "region"
+    value = var.region
+  }
+
+  set {
+    name  = "vpcId"
+    value = module.vpc.vpc_id
+  }
+
+  depends_on = [
+    module.load_balancer_controller_irsa_role,
+  ]
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.32.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.15.0"
+    }
   }
 }
 
@@ -41,4 +45,12 @@ provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   token                  = data.aws_eks_cluster_auth.cluster.token
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  }
 }


### PR DESCRIPTION
* Add Helm provider to Terraform
* Install AWS Load Balancer Controller via Helm
* Create required IRSA role

Required for #7 to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced AWS Load Balancer Controller deployment within EKS, enhancing load balancer management.
	- Added Helm provider support for streamlined deployment of Kubernetes applications.

- **Improvements**
	- Configured IAM role for the Load Balancer Controller, ensuring proper permissions and service account management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->